### PR TITLE
php 7.2

### DIFF
--- a/php/7.2/Dockerfile
+++ b/php/7.2/Dockerfile
@@ -1,0 +1,113 @@
+FROM php:7.2
+
+MAINTAINER Mads Møller <mm@napp.dk>
+
+ENV XDEBUG_VERSION 2.6.0
+
+# Install php extensions
+RUN buildDeps=" \
+        freetds-dev \
+        libbz2-dev \
+        libc-client-dev \
+        libenchant-dev \
+        libfreetype6-dev \
+        libgmp3-dev \
+        libicu-dev \
+        libjpeg62-turbo-dev \
+        libkrb5-dev \
+        libldap2-dev \
+        libpng-dev \
+        libpq-dev \
+        libpspell-dev \
+        librabbitmq-dev \
+        libsasl2-dev \
+        libsnmp-dev \
+        libssl-dev \
+        libtidy-dev \
+        libxml2-dev \
+        libxpm-dev \
+        libxslt1-dev \
+        zlib1g-dev \
+    " \
+    && phpModules=" \
+        bcmath bz2 calendar dba enchant exif ftp gd gettext gmp imap intl ldap mbstring mysqli opcache pcntl pdo pdo_dblib pdo_mysql pdo_pgsql pgsql pspell shmop snmp soap sockets sysvmsg sysvsem sysvshm tidy wddx xmlrpc xsl zip xdebug \
+    " \
+    && echo "deb http://httpredir.debian.org/debian stretch contrib non-free" > /etc/apt/sources.list.d/additional.list \
+    && apt-get update && apt-get install -y libc-client2007e libenchant1c2a libfreetype6 libicu57 libjpeg62-turbo libpng16-16 libpq5 libsybdb5 libtidy5 libx11-6 libxpm4 libxslt1.1 snmp --no-install-recommends \
+    && apt-get install -y $buildDeps --no-install-recommends \
+    && docker-php-source extract \
+    && cd /usr/src/php/ext/ \
+
+    # Xdebug
+    && curl -L http://xdebug.org/files/xdebug-$XDEBUG_VERSION.tgz | tar -zxf - \
+    && mv xdebug-$XDEBUG_VERSION xdebug \
+
+    # extensions
+    && ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h \
+    && ln -s /usr/lib/x86_64-linux-gnu/libldap_r.so /usr/lib/libldap.so \
+    && ln -s /usr/lib/x86_64-linux-gnu/libldap_r.a /usr/lib/libldap_r.a \
+    && ln -s /usr/lib/x86_64-linux-gnu/libsybdb.a /usr/lib/libsybdb.a \
+    && ln -s /usr/lib/x86_64-linux-gnu/libsybdb.so /usr/lib/libsybdb.so \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-xpm-dir=/usr/include/ \
+    && docker-php-ext-configure imap --with-imap --with-kerberos --with-imap-ssl \
+    && docker-php-ext-configure ldap --with-ldap-sasl \
+    && docker-php-ext-install $phpModules \
+
+    # PECL modules
+    && printf "\n" | pecl install amqp \
+    && pecl install igbinary \
+#    && printf "\n" | pecl install memcache \
+    && pecl install mongodb \
+    && pecl install redis \
+    && for ext in $phpModules; do \
+           rm -f /usr/local/etc/php/conf.d/docker-php-ext-$ext.ini; \
+       done \
+    && docker-php-source delete \
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps
+
+# Install additional packages
+RUN apt-get update && apt-get install -y git mysql-client msmtp-mta openssh-client rsync --no-install-recommends && rm -r /var/lib/apt/lists/*
+
+# Install composer and put binary into $PATH
+RUN curl -sS https://getcomposer.org/installer | php \
+    && mv composer.phar /usr/local/bin/ \
+    && ln -s /usr/local/bin/composer.phar /usr/local/bin/composer
+
+# Install phpunit and put binary into $PATH
+RUN curl -sSLo phpunit.phar https://phar.phpunit.de/phpunit.phar \
+    && chmod 755 phpunit.phar \
+    && mv phpunit.phar /usr/local/bin/ \
+    && ln -s /usr/local/bin/phpunit.phar /usr/local/bin/phpunit
+
+# Install PHP Code sniffer
+RUN curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar \
+    && chmod 755 phpcs.phar \
+    && mv phpcs.phar /usr/local/bin/ \
+    && ln -s /usr/local/bin/phpcs.phar /usr/local/bin/phpcs \
+    && curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar \
+    && chmod 755 phpcbf.phar \
+    && mv phpcbf.phar /usr/local/bin/ \
+    && ln -s /usr/local/bin/phpcbf.phar /usr/local/bin/phpcbf
+
+# Install PHP Mess Detector
+RUN curl -OL http://static.phpmd.org/php/latest/phpmd.phar \
+    && chmod 755 phpmd.phar \
+    && mv phpmd.phar /usr/local/bin \
+    && ln -s /usr/local/bin/phpmd.phar /usr/local/bin/phpmd
+
+# Install Node.js
+RUN apt-get update && apt-get -y install apt-utils gnupg && apt-get install -y build-essential \
+    && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
+    && apt-get install -y nodejs
+
+# Install Yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update && apt-get install yarn
+
+RUN rm -r /var/lib/apt/lists/* && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false;
+
+COPY msmtprc /etc/
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["php", "-a"]

--- a/php/7.2/entrypoint.sh
+++ b/php/7.2/entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+# With env variable WITH_XDEBUG=1 xdebug extension will be enabled
+[ ! -z "$WITH_XDEBUG" ] && docker-php-ext-enable xdebug
+
+# Provide github token if you are using composer a lot in non-interactive mode
+# Otherwise one day it will get stuck with request for authorization
+# https://github.com/settings/tokens
+if [[ ! -z "$COMPOSER_GITHUB" ]]
+then
+  composer config --global github-oauth.github.com "$COMPOSER_GITHUB"
+fi
+
+#
+# If $TIMEZONE variable is passed to the image - it will set system timezone
+# and php.ini date.timezone value as well
+# Overwise the default system Etc/UTC timezone will be used
+#
+# Also you can set the php timezone with direct setting it in php.ini
+# within your .gitlab-ci.yml like
+# before_script:
+# - echo "America/New_York" > /usr/local/etc/php/conf.d/timezone.ini
+
+if [[ ! -z "$TIMEZONE" ]]
+then
+  echo "$TIMEZONE" > /etc/timezone
+  dpkg-reconfigure -f noninteractive tzdata
+fi
+echo "date.timezone=`cat /etc/timezone`" > /usr/local/etc/php/conf.d/timezone.ini
+
+exec "$@"

--- a/php/7.2/fpm/Dockerfile
+++ b/php/7.2/fpm/Dockerfile
@@ -1,0 +1,110 @@
+FROM php:7.2-fpm
+
+MAINTAINER Mads Møller <mm@napp.dk>
+
+ENV XDEBUG_VERSION 2.6.0
+
+# Install php extensions
+RUN buildDeps=" \
+        freetds-dev \
+        libbz2-dev \
+        libc-client-dev \
+        libenchant-dev \
+        libfreetype6-dev \
+        libgmp3-dev \
+        libicu-dev \
+        libjpeg62-turbo-dev \
+        libkrb5-dev \
+        libldap2-dev \
+        libpng-dev \
+        libpq-dev \
+        libpspell-dev \
+        librabbitmq-dev \
+        libsasl2-dev \
+        libsnmp-dev \
+        libssl-dev \
+        libtidy-dev \
+        libxml2-dev \
+        libxpm-dev \
+        libxslt1-dev \
+        zlib1g-dev \
+    " \
+    && phpModules=" \
+        bcmath bz2 calendar dba enchant exif ftp gd gettext gmp imap intl ldap mbstring mysqli opcache pcntl pdo pdo_dblib pdo_mysql pdo_pgsql pgsql pspell shmop snmp soap sockets sysvmsg sysvsem sysvshm tidy wddx xmlrpc xsl zip xdebug \
+    " \
+    && echo "deb http://httpredir.debian.org/debian stretch contrib non-free" > /etc/apt/sources.list.d/additional.list \
+    && apt-get update && apt-get install -y libc-client2007e libenchant1c2a libfreetype6 libicu57 libjpeg62-turbo libpng16-16 libpq5 libsybdb5 libtidy5 libx11-6 libxpm4 libxslt1.1 snmp --no-install-recommends \
+    && apt-get install -y $buildDeps --no-install-recommends \
+    && docker-php-source extract \
+    && cd /usr/src/php/ext/ \
+
+    # Xdebug
+    && curl -L http://xdebug.org/files/xdebug-$XDEBUG_VERSION.tgz | tar -zxf - \
+    && mv xdebug-$XDEBUG_VERSION xdebug \
+
+    # extensions
+    && ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h \
+    && ln -s /usr/lib/x86_64-linux-gnu/libldap_r.so /usr/lib/libldap.so \
+    && ln -s /usr/lib/x86_64-linux-gnu/libldap_r.a /usr/lib/libldap_r.a \
+    && ln -s /usr/lib/x86_64-linux-gnu/libsybdb.a /usr/lib/libsybdb.a \
+    && ln -s /usr/lib/x86_64-linux-gnu/libsybdb.so /usr/lib/libsybdb.so \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-xpm-dir=/usr/include/ \
+    && docker-php-ext-configure imap --with-imap --with-kerberos --with-imap-ssl \
+    && docker-php-ext-configure ldap --with-ldap-sasl \
+    && docker-php-ext-install $phpModules \
+
+    # PECL modules
+    && printf "\n" | pecl install amqp \
+    && pecl install igbinary \
+#    && printf "\n" | pecl install memcache \
+    && pecl install mongodb \
+    && pecl install redis \
+    && for ext in $phpModules; do \
+           rm -f /usr/local/etc/php/conf.d/docker-php-ext-$ext.ini; \
+       done \
+    && docker-php-source delete \
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps
+
+# Install additional packages
+RUN apt-get update && apt-get install -y git mysql-client msmtp-mta openssh-client rsync --no-install-recommends && rm -r /var/lib/apt/lists/*
+
+# Install composer and put binary into $PATH
+RUN curl -sS https://getcomposer.org/installer | php \
+    && mv composer.phar /usr/local/bin/ \
+    && ln -s /usr/local/bin/composer.phar /usr/local/bin/composer
+
+# Install phpunit and put binary into $PATH
+RUN curl -sSLo phpunit.phar https://phar.phpunit.de/phpunit.phar \
+    && chmod 755 phpunit.phar \
+    && mv phpunit.phar /usr/local/bin/ \
+    && ln -s /usr/local/bin/phpunit.phar /usr/local/bin/phpunit
+
+# Install PHP Code sniffer
+RUN curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar \
+    && chmod 755 phpcs.phar \
+    && mv phpcs.phar /usr/local/bin/ \
+    && ln -s /usr/local/bin/phpcs.phar /usr/local/bin/phpcs \
+    && curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar \
+    && chmod 755 phpcbf.phar \
+    && mv phpcbf.phar /usr/local/bin/ \
+    && ln -s /usr/local/bin/phpcbf.phar /usr/local/bin/phpcbf
+
+# Install PHP Mess Detector
+RUN curl -OL http://static.phpmd.org/php/latest/phpmd.phar \
+    && chmod 755 phpmd.phar \
+    && mv phpmd.phar /usr/local/bin \
+    && ln -s /usr/local/bin/phpmd.phar /usr/local/bin/phpmd
+
+# Install Node.js
+RUN apt-get update && apt-get -y install apt-utils gnupg && apt-get install -y build-essential \
+    && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
+    && apt-get install -y nodejs
+
+# Install Yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update && apt-get install yarn
+
+RUN rm -r /var/lib/apt/lists/* && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false;
+
+COPY msmtprc /etc/

--- a/php/7.2/fpm/msmtprc
+++ b/php/7.2/fpm/msmtprc
@@ -1,0 +1,18 @@
+# A system wide configuration is optional.
+# If it exists, it usually defines a default account.
+# This allows msmtp to be used like /usr/sbin/sendmail.
+account default
+
+# The SMTP smarthost.
+host localhost
+
+# Construct envelope-from addresses of the form "user@oursite.example".
+#auto_from on
+#maildomain oursite.example
+
+# Use TLS.
+#tls on
+#tls_trust_file /etc/ssl/certs/ca-certificates.crt
+
+# Syslog logging with facility LOG_MAIL instead of the default LOG_USER.
+#syslog LOG_MAIL

--- a/php/7.2/msmtprc
+++ b/php/7.2/msmtprc
@@ -1,0 +1,18 @@
+# A system wide configuration is optional.
+# If it exists, it usually defines a default account.
+# This allows msmtp to be used like /usr/sbin/sendmail.
+account default
+
+# The SMTP smarthost.
+host localhost
+
+# Construct envelope-from addresses of the form "user@oursite.example".
+#auto_from on
+#maildomain oursite.example
+
+# Use TLS.
+#tls on
+#tls_trust_file /etc/ssl/certs/ca-certificates.crt
+
+# Syslog logging with facility LOG_MAIL instead of the default LOG_USER.
+#syslog LOG_MAIL


### PR DESCRIPTION
@viezel Second pass at php 7.2 ci build.

Build locally and tested with a local gitlab-runner using fallowing command `gitlab-runner exec docker (suite)` with my test image `lundz/php-ci:7.2`.

I'm not sure if the docker builds will go up by them self. 

The only real difference in these builds is that are:
* They are build out of debian strech (eg. debian 9) instead of debian jessie (debian 8)
* phpunit is version 7.x
* Node is version 8.x (we may even consider going for node 10.x)
* PHPmd is version 2.6.x
* Code sniffer version is 3.3.x
* PHPunit is version 7.2.x
* PHP's Curl module has build-in support for `http/2`
* PHP is also compiled with the `--with-password-argon2` flag so we can use argon in the future.